### PR TITLE
set prefix after pagination but before yield

### DIFF
--- a/src/soundcharts/artist.py
+++ b/src/soundcharts/artist.py
@@ -406,5 +406,6 @@ class Artist(Client):
             params["sortBy"] = sortBy
         if sortOrder:
             params["sortOrder"] = sortOrder
-        yield from self._get_paginated(url, params=params)
+        paginated = self._get_paginated(url, params=params)
         self._prefix = "/api/v2/artist"
+        yield from paginated


### PR DESCRIPTION
### What changes:
`self._prefix` will be reset to its original value just before yielding the pagination results.

### What resolves:
Yielding the pagination right before resetting `_prefix` has been causing some queries after this hits a non-existing endpoint:

```
https://customer.api.soundcharts.com/api/v2.21/artist/158c1b98-c59b-11e8-a2bb-549f35141000/streaming/spotify/listeners/2022/07
https://customer.api.soundcharts.com/api/v2.21/artist/158c1b98-c59b-11e8-a2bb-549f35141000/playlist/current/spotify
https://customer.api.soundcharts.com/api/v2.21/artist/158c1b98-c59b-11e8-a2bb-549f35141000/identifiers
https://customer.api.soundcharts.com/api/v2.21/artist/158c1b98-c59b-11e8-a2bb-549f35141000/songs
```

From the quick sample above, only `/api/v2.21/artist/{uuid}/songs` should make use of v2.21