### PR TITLE
Revert last changes

### DIFF
--- a/src/soundcharts/artist.py
+++ b/src/soundcharts/artist.py
@@ -406,6 +406,5 @@ class Artist(Client):
             params["sortBy"] = sortBy
         if sortOrder:
             params["sortOrder"] = sortOrder
-        paginated = self._get_paginated(url, params=params)
+        yield from self._get_paginated(url, params=params)
         self._prefix = "/api/v2/artist"
-        yield from paginated


### PR DESCRIPTION
### What changes:
Last change where yield was moved to the end of the `songs()` def has been reverted.

### What resolves:
It was just an unnecessary fix and the issues didn't lie in there as explained in the related issue/PR https://github.com/weareinstrumental/collaboration-tool/pull/12